### PR TITLE
fix: Allows non-consecutive header levels

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -64,6 +64,7 @@ if not 'ogp_image' in locals():
 ### General configuration
 ############################################################
 
+suppress_warnings = ["myst.header"]
 exclude_patterns = [
     '_build',
     'Thumbs.db',


### PR DESCRIPTION
Fixes documentation building error:
```
/home/docs/checkouts/readthedocs.org/user_builds/canonical-chaos-engineering/checkouts/latest/docs/how-to/run_chaos_experiments.md.rst:7: WARNING: Non-consecutive header level increase; H1 to H3 [myst.header]
(...)
build finished with problems, 1 warning (with warnings treated as errors).
```